### PR TITLE
Skip completely empty ontology sources

### DIFF
--- a/altamisa/exceptions.py
+++ b/altamisa/exceptions.py
@@ -6,8 +6,16 @@ __author__ = 'Manuel Holtgrewe <manuel.holtgrewe@bihealth.de>'
 
 
 class IsaException(Exception):
-    """Base class for exceptions raised by monal-ISA"""
+    """Base class for exceptions raised by Altamisa"""
 
 
 class ParseIsatabException(IsaException):
     """Exception raised on problems parsing ISA-TAB"""
+
+
+class IsaWarning(Warning):
+    """Base class for warnings raised by Altamisa"""
+
+
+class ParseIsatabWarning(IsaWarning):
+    """Warning raised on problems parsing ISA-TAB"""


### PR DESCRIPTION
Needed to skip empty ontology source columns, since ISAcreator always adds one even if one or more ontology sources are available.

I initiated a Warning class in the same fashion as the ParseIsatabException. Is it useful/appropriate to provide and use a warning for cases like this?