### PR TITLE
Refactor protocol parameter and components as dict

### DIFF
--- a/altamisa/isatab/models.py
+++ b/altamisa/isatab/models.py
@@ -204,9 +204,9 @@ class ProtocolInfo(NamedTuple):
     #: Protocol version
     version: str
     #: Protocol parameters
-    parameters: Tuple[FreeTextOrTermRef]
+    parameters: Dict[str, FreeTextOrTermRef]
     #: Protocol components
-    component: Tuple[ProtocolComponentInfo]
+    components: Dict[str, ProtocolComponentInfo]
     #: Comments
     comments: Dict[str, str]
 

--- a/altamisa/isatab/parse_investigation.py
+++ b/altamisa/isatab/parse_investigation.py
@@ -282,8 +282,18 @@ def _split_study_protocols_parameters(
         tpl = 'Unequal protocol parameter splits; found: "{}", "{}", "{}"'
         msg = tpl.format(names, name_term_accs, name_term_srcs)
         raise ParseIsatabException(msg)
+    if len(names) > len(set(names)):
+        tpl = 'Repeated protocol parameter; found: {}'
+        msg = tpl.format(names)
+        raise ParseIsatabException(msg)
     for (name, acc, src) in zip(names, name_term_accs, name_term_srcs):
-        yield models.OntologyTermRef(name, acc, src)
+        if not name and (acc or src):
+            tpl = 'Missing protocol parameter name; found: "{}", "{}", "{}"'
+            msg = tpl.format(name, acc, src)
+            raise ParseIsatabException(msg)
+        # TODO: should yield string, if acc and src are empty?
+        if any((name, acc, src)):  # skips empty parameters
+            yield models.OntologyTermRef(name, acc, src)
 
 
 # Helper function to extract protocol components
@@ -300,10 +310,21 @@ def _split_study_protocols_components(
                'found: "{}", "{}", "{}", "{}"')
         msg = tpl.format(names, types, type_term_accs, type_term_srcs)
         raise ParseIsatabException(msg)
-    for (name, ctype, acc, src) in zip(names, types, type_term_accs,
-                                       type_term_srcs):
-        yield models.ProtocolComponentInfo(
-            name, models.OntologyTermRef(ctype, acc, src))
+    if len(names) > len(set(names)):
+        tpl = 'Repeated protocol components; found: {}'
+        msg = tpl.format(names)
+        raise ParseIsatabException(msg)
+    for (name, ctype, acc, src) in zip(
+            names, types, type_term_accs, type_term_srcs):
+        if not name and any((ctype, acc, src)):
+            tpl = ('Missing protocol parameter name; '
+                   'found: "{}", "{}", "{}", "{}"')
+            msg = tpl.format(name, ctype, acc, src)
+            raise ParseIsatabException(msg)
+        # TODO: should yield string, if acc and src are empty?
+        if any((name, ctype, acc, src)):  # skips empty components
+            yield models.ProtocolComponentInfo(
+                name, models.OntologyTermRef(ctype, acc, src))
 
 
 class InvestigationReader:
@@ -566,10 +587,10 @@ class InvestigationReader:
         # Create resulting objects
         columns = zip(*(section[k] for k in STUDY_DESIGN_DESCR_KEYS))
         for i, (type_term, type_term_acc, type_term_src) in enumerate(columns):
-            type = models.OntologyTermRef(
+            otype = models.OntologyTermRef(
                 type_term, type_term_acc, type_term_src)
             comments = _parse_comments(section, comment_keys, i)
-            yield models.DesignDescriptorsInfo(type, comments)
+            yield models.DesignDescriptorsInfo(otype, comments)
 
     def _read_study_publications(self) -> Iterator[models.PublicationInfo]:
         # Read STUDY PUBLICATIONS header
@@ -664,11 +685,11 @@ class InvestigationReader:
                 raise ParseIsatabException(msg)
             type_ont = models.OntologyTermRef(
                 type_term, type_term_acc, type_term_src)
-            paras = tuple(_split_study_protocols_parameters(
-                para_names, para_name_term_accs, para_name_term_srcs))
-            comps = tuple(_split_study_protocols_components(
+            paras = {p.name: p for p in _split_study_protocols_parameters(
+                para_names, para_name_term_accs, para_name_term_srcs)}
+            comps = {c.name: c for c in _split_study_protocols_components(
                 comp_names, comp_types, comp_type_term_accs,
-                comp_type_term_srcs))
+                comp_type_term_srcs)}
             comments = _parse_comments(section, comment_keys, i)
             yield models.ProtocolInfo(name, type_ont, description, uri,
                                       version, paras, comps, comments)

--- a/tests/test_parse_investigation.py
+++ b/tests/test_parse_investigation.py
@@ -276,24 +276,22 @@ def test_parse_full_investigation(full_investigation_file):
         " Technologies). RNA was quantified using the Nanodrop ultra low "
         "volume spectrophotometer (Nanodrop Technologies).",
         "", "",
-        (models.OntologyTermRef(
-            "rate", "http://purl.obolibrary.org/obo/PATO_0000161", "PATO"), ),
-        (models.ProtocolComponentInfo("",
-                                      models.OntologyTermRef("", "", "")), ),
-        {})
+        {"rate": models.OntologyTermRef(
+            "rate", "http://purl.obolibrary.org/obo/PATO_0000161", "PATO"), },
+        {}, {})
     assert expected == study.protocols["growth protocol"]
     expected = models.ProtocolInfo(
         "metabolite extraction",
         models.OntologyTermRef(
             "extraction", "http://purl.obolibrary.org/obo/OBI_0302884", "OBI"),
         "",  "", "",
-        (models.OntologyTermRef("standard volume", "", ""),
-         models.OntologyTermRef("sample volume", "", "")),
-        (models.ProtocolComponentInfo(
+        {"standard volume": models.OntologyTermRef("standard volume", "", ""),
+         "sample volume": models.OntologyTermRef("sample volume", "", "")},
+        {"pipette": models.ProtocolComponentInfo(
             "pipette", models.OntologyTermRef(
                 "instrument",
                 "http://www.ebi.ac.uk/efo/EFO_0000548",
-                "EFO")), ), {})
+                "EFO")), }, {})
     assert expected == study.protocols["metabolite extraction"]
 
     # Study 1 - Contacts
@@ -398,14 +396,14 @@ def test_parse_full_investigation(full_investigation_file):
             "http://purl.obolibrary.org/obo/OBI_0000623",
             "OBI"),
         "", "", "",
-        (models.OntologyTermRef("", "", ""), ),
-        (models.ProtocolComponentInfo("NMR tubes",
-                                      models.OntologyTermRef("", "", "")),
-         models.ProtocolComponentInfo("Bruker-Av600",
-                                      models.OntologyTermRef(
-                                          "instrument",
-                                          "http://www.ebi.ac.uk/efo/EFO_0000548",
-                                          "EFO"))), {})
+        {},
+        {"NMR tubes": models.ProtocolComponentInfo(
+            "NMR tubes", models.OntologyTermRef("", "", "")),
+         "Bruker-Av600": models.ProtocolComponentInfo(
+             "Bruker-Av600", models.OntologyTermRef(
+                 "instrument",
+                 "http://www.ebi.ac.uk/efo/EFO_0000548",
+                 "EFO"))}, {})
     assert expected == study.protocols["NMR spectroscopy"]
 
     # Study 2 - Contacts
@@ -534,13 +532,13 @@ def test_parse_comment_investigation(comment_investigation_file):
         models.OntologyTermRef(
             "extraction", "http://purl.obolibrary.org/obo/OBI_0302884", "OBI"),
         "", "", "",
-        (models.OntologyTermRef("standard volume", "", ""),
-         models.OntologyTermRef("sample volume", "", "")),
-        (models.ProtocolComponentInfo(
+        {"standard volume": models.OntologyTermRef("standard volume", "", ""),
+         "sample volume": models.OntologyTermRef("sample volume", "", "")},
+        {"pipette": models.ProtocolComponentInfo(
             "pipette", models.OntologyTermRef(
                 "instrument",
                 "http://www.ebi.ac.uk/efo/EFO_0000548",
-                "EFO")),),
+                "EFO"))},
         {"ProtocolsComment": "TestValue01"})
     assert expected == study.protocols["metabolite extraction"]
 


### PR DESCRIPTION
Putting protocol parameters and components in dictionaries to enable query by name (will be needed e.g. to check if a parameter used in study/assay processes is declared).