### PR TITLE
Enable Unit ontology annotation

### DIFF
--- a/altamisa/isatab/parse_assay_study.py
+++ b/altamisa/isatab/parse_assay_study.py
@@ -204,7 +204,7 @@ class _NodeBuilderBase:
                     prev.term_source_ref_header = header
                     is_secondary = True
             elif header.column_type == 'Unit':
-                if prev.term_source_ref_header:
+                if prev.unit_header or prev.column_type == 'Unit':
                     tpl = 'Seen "Unit" header for same entity in col {}'
                     msg = tpl.format(header.col_no)
                     raise ParseIsatabException(msg)
@@ -212,7 +212,6 @@ class _NodeBuilderBase:
                     # The previous non-secondary header is annotated with a
                     # unit.
                     prev.unit_header = header
-                    is_secondary = True
             # Update is secondary flag or not
             if not is_secondary:
                 prev = header

--- a/tests/data/i_small/i_small.txt
+++ b/tests/data/i_small/i_small.txt
@@ -1,8 +1,8 @@
 ONTOLOGY SOURCE REFERENCE
-Term Source Name	OBI	NCBITAXON	ROLEO
-Term Source File	http://data.bioontology.org/ontologies/OBI	http://data.bioontology.org/ontologies/NCBITAXON	http://data.bioontology.org/ontologies/ROLEO
-Term Source Version	31	8	1
-Term Source Description	Ontology for Biomedical Investigations	National Center for Biotechnology Information (NCBI) Organismal Classification	Role Ontology
+Term Source Name	OBI	NCBITAXON	ROLEO	UO
+Term Source File	http://data.bioontology.org/ontologies/OBI	http://data.bioontology.org/ontologies/NCBITAXON	http://data.bioontology.org/ontologies/ROLEO	http://data.bioontology.org/ontologies/UO
+Term Source Version	31	8	1	43
+Term Source Description	Ontology for Biomedical Investigations	National Center for Biotechnology Information (NCBI) Organismal Classification	Role Ontology	Units of Measurement Ontology
 INVESTIGATION
 Investigation Identifier	i_small
 Investigation Title	Small Investigation

--- a/tests/data/i_small/s_small.txt
+++ b/tests/data/i_small/s_small.txt
@@ -1,5 +1,5 @@
-Source Name	Characteristics[organism]	Term Source REF	Term Accession Number	Characteristics[age]	Unit	Term Source REF	Term Accession Number	Protocol REF	Performer	Date	Sample Name
-0815	Mus musculus	NCBITAXON	http://purl.bioontology.org/ontology/NCBITAXON/10090	90	day	UO	http://purl.obolibrary.org/obo/UO_0000033	sample collection	John Doe	2018-02-02	0815-N1
-0815	Mus musculus	NCBITAXON	http://purl.bioontology.org/ontology/NCBITAXON/10090	90	day	UO	http://purl.obolibrary.org/obo/UO_0000033	sample collection	John Doe	2018-02-02	0815-T1
-0816	Mus musculus			120	day	UO	http://purl.obolibrary.org/obo/UO_0000033	sample collection	John Doe	2018-02-02	0816-T1
-0817				150	day	UO	http://purl.obolibrary.org/obo/UO_0000033	sample collection	John Doe	2018-02-02	0817-T1
+Source Name	Characteristics[organism]	Term Source REF	Term Accession Number	Characteristics[age]	Unit	Term Source REF	Term Accession Number	Protocol REF	Performer	Date	Sample Name	Characteristics[status]
+0815	Mus musculus	NCBITAXON	http://purl.bioontology.org/ontology/NCBITAXON/10090	90	day	UO	http://purl.obolibrary.org/obo/UO_0000033	sample collection	John Doe	2018-02-02	0815-N1	0
+0815	Mus musculus	NCBITAXON	http://purl.bioontology.org/ontology/NCBITAXON/10090	90	day	UO	http://purl.obolibrary.org/obo/UO_0000033	sample collection	John Doe	2018-02-02	0815-T1	2
+0816	Mus musculus			120	day	UO	http://purl.obolibrary.org/obo/UO_0000033	sample collection	John Doe	2018-02-02	0816-T1	1
+0817				150	day	UO	http://purl.obolibrary.org/obo/UO_0000033	sample collection	John Doe	2018-02-02	0817-T1	2

--- a/tests/data/i_small/s_small.txt
+++ b/tests/data/i_small/s_small.txt
@@ -1,5 +1,5 @@
-Source Name	Characteristics[organism]	Term Source REF	Term Accession Number	Protocol REF	Performer	Date	Sample Name
-0815	Mus musculus	NCBITAXON	http://purl.bioontology.org/ontology/NCBITAXON/10090	sample collection	John Doe	2018-02-02	0815-N1
-0815	Mus musculus	NCBITAXON	http://purl.bioontology.org/ontology/NCBITAXON/10090	sample collection	John Doe	2018-02-02	0815-T1
-0816	Mus musculus			sample collection	John Doe	2018-02-02	0816-T1
-0817				sample collection	John Doe	2018-02-02	0817-T1
+Source Name	Characteristics[organism]	Term Source REF	Term Accession Number	Characteristics[age]	Unit	Term Source REF	Term Accession Number	Protocol REF	Performer	Date	Sample Name
+0815	Mus musculus	NCBITAXON	http://purl.bioontology.org/ontology/NCBITAXON/10090	90	day	UO	http://purl.obolibrary.org/obo/UO_0000033	sample collection	John Doe	2018-02-02	0815-N1
+0815	Mus musculus	NCBITAXON	http://purl.bioontology.org/ontology/NCBITAXON/10090	90	day	UO	http://purl.obolibrary.org/obo/UO_0000033	sample collection	John Doe	2018-02-02	0815-T1
+0816	Mus musculus			120	day	UO	http://purl.obolibrary.org/obo/UO_0000033	sample collection	John Doe	2018-02-02	0816-T1
+0817				150	day	UO	http://purl.obolibrary.org/obo/UO_0000033	sample collection	John Doe	2018-02-02	0817-T1

--- a/tests/test_parse_investigation.py
+++ b/tests/test_parse_investigation.py
@@ -51,7 +51,7 @@ def test_parse_small_investigation(small_investigation_file):
     assert investigation
 
     # Ontology sources
-    assert 3 == len(investigation.ontology_source_refs)
+    assert 4 == len(investigation.ontology_source_refs)
     expected = models.OntologyRef(
         'OBI', 'http://data.bioontology.org/ontologies/OBI',
         '31', 'Ontology for Biomedical Investigations', {})

--- a/tests/test_parse_study.py
+++ b/tests/test_parse_study.py
@@ -91,7 +91,7 @@ def test_study_row_reader_small_study(
 
     # Create new row reader and check read headers
     row_reader = StudyRowReader.from_stream(investigation, small_study_file)
-    assert 7 == len(row_reader.header)
+    assert 10 == len(row_reader.header)
 
     # Read all rows in study
     rows = list(row_reader.read())
@@ -103,19 +103,28 @@ def test_study_row_reader_small_study(
 
     assert 3 == len(first_row)
 
-    characteristics = models.Characteristics(
-        name='organism',
-        value=models.OntologyTermRef(
-            name='Mus musculus',
-            accession='http://purl.bioontology.org/ontology/NCBITAXON/10090',
-            ontology_name='NCBITAXON'),
-        unit=None)
+    unit = models.OntologyTermRef(
+        name='day',
+        accession='http://purl.obolibrary.org/obo/UO_0000033',
+        ontology_name='UO'
+    )
+
+    characteristics = (
+        models.Characteristics(
+            name='organism',
+            value=models.OntologyTermRef(
+                name='Mus musculus',
+                accession='http://purl.bioontology.org/ontology/'
+                          'NCBITAXON/10090',
+                ontology_name='NCBITAXON'),
+            unit=None),
+        models.Characteristics(name='age', value='90', unit=unit))
 
     expected = models.Material(
-        'Source Name', 'source-0815', None, (characteristics,), (), (), None)
+        'Source Name', 'source-0815', None, characteristics, (), (), None)
     assert expected == first_row[0]
     expected = models.Process(
-        'sample collection', 'sample collection-5-1', date(2018, 2, 2),
+        'sample collection', 'sample collection-9-1', date(2018, 2, 2),
         'John Doe', (), (), None, None)
     assert expected == first_row[1]
     expected = models.Material(
@@ -124,10 +133,10 @@ def test_study_row_reader_small_study(
 
     assert 3 == len(second_row)
     expected = models.Material(
-        'Source Name', 'source-0815', None, (characteristics,), (), (), None)
+        'Source Name', 'source-0815', None, characteristics, (), (), None)
     assert expected == second_row[0]
     expected = models.Process(
-        'sample collection', 'sample collection-5-2', date(2018, 2, 2),
+        'sample collection', 'sample collection-9-2', date(2018, 2, 2),
         'John Doe', (), (), None, None)
     assert expected == second_row[1]
     expected = models.Material(
@@ -143,42 +152,55 @@ def test_study_reader_small_study(
 
     # Create new row reader and check read headers
     reader = StudyReader.from_stream(investigation, small_study_file)
-    assert 7 == len(reader.header)
+    assert 10 == len(reader.header)
 
     # Read study
     study = reader.read()
 
     # Check results
     assert str(study.file).endswith('data/i_small/s_small.txt')
-    assert 7 == len(study.header)
+    assert 10 == len(study.header)
     assert 7 == len(study.materials)
     assert 4 == len(study.processes)
     assert 8 == len(study.arcs)
 
-    characteristics1 = models.Characteristics(
-        name='organism',
-        value=models.OntologyTermRef(
-            name='Mus musculus',
-            accession='http://purl.bioontology.org/ontology/NCBITAXON/10090',
-            ontology_name='NCBITAXON'),
-        unit=None)
-    characteristics2 = models.Characteristics(
-        name='organism',
-        value='Mus musculus',
-        unit=None)
-    characteristics3 = models.Characteristics(
-        name='organism',
-        value=None,
-        unit=None)
+    unit = models.OntologyTermRef(
+        name='day',
+        accession='http://purl.obolibrary.org/obo/UO_0000033',
+        ontology_name='UO'
+    )
+
+    characteristics1 = (
+        models.Characteristics(
+            name='organism',
+            value=models.OntologyTermRef(
+                name='Mus musculus',
+                accession='http://purl.bioontology.org/ontology/'
+                          'NCBITAXON/10090',
+                ontology_name='NCBITAXON'),
+            unit=None),
+        models.Characteristics(name='age', value='90', unit=unit))
+    characteristics2 = (
+        models.Characteristics(
+            name='organism',
+            value='Mus musculus',
+            unit=None),
+        models.Characteristics(name='age', value='120', unit=unit))
+    characteristics3 = (
+        models.Characteristics(
+            name='organism',
+            value=None,
+            unit=None),
+        models.Characteristics(name='age', value='150', unit=unit))
 
     expected = models.Material(
-        'Source Name', 'source-0815', None, (characteristics1,), (), (), None)
+        'Source Name', 'source-0815', None, characteristics1, (), (), None)
     assert expected == study.materials['source-0815']
     expected = models.Material(
-        'Source Name', 'source-0816', None, (characteristics2,), (), (), None)
+        'Source Name', 'source-0816', None, characteristics2, (), (), None)
     assert expected == study.materials['source-0816']
     expected = models.Material(
-        'Source Name', 'source-0817', None, (characteristics3,), (), (), None)
+        'Source Name', 'source-0817', None, characteristics3, (), (), None)
     assert expected == study.materials['source-0817']
     expected = models.Material(
         'Sample Name', 'sample-0815-N1', None, (), (), (), None)
@@ -194,26 +216,26 @@ def test_study_reader_small_study(
     assert expected == study.materials['sample-0817-T1']
 
     expected = models.Process(
-        'sample collection', 'sample collection-5-1', date(2018, 2, 2),
+        'sample collection', 'sample collection-9-1', date(2018, 2, 2),
         'John Doe', (), (), None, None)
-    assert expected == study.processes['sample collection-5-1']
+    assert expected == study.processes['sample collection-9-1']
     expected = models.Process(
-        'sample collection', 'sample collection-5-2', date(2018, 2, 2),
+        'sample collection', 'sample collection-9-2', date(2018, 2, 2),
         'John Doe', (), (), None, None)
-    assert expected == study.processes['sample collection-5-2']
+    assert expected == study.processes['sample collection-9-2']
     expected = models.Process(
-        'sample collection', 'sample collection-5-3', date(2018, 2, 2),
+        'sample collection', 'sample collection-9-3', date(2018, 2, 2),
         'John Doe', (), (), None, None)
-    assert expected == study.processes['sample collection-5-3']
+    assert expected == study.processes['sample collection-9-3']
 
     expected = (
-        models.Arc('source-0815', 'sample collection-5-1'),
-        models.Arc('sample collection-5-1', 'sample-0815-N1'),
-        models.Arc('source-0815', 'sample collection-5-2'),
-        models.Arc('sample collection-5-2', 'sample-0815-T1'),
-        models.Arc('source-0816', 'sample collection-5-3'),
-        models.Arc('sample collection-5-3', 'sample-0816-T1'),
-        models.Arc('source-0817', 'sample collection-5-4'),
-        models.Arc('sample collection-5-4', 'sample-0817-T1'),
+        models.Arc('source-0815', 'sample collection-9-1'),
+        models.Arc('sample collection-9-1', 'sample-0815-N1'),
+        models.Arc('source-0815', 'sample collection-9-2'),
+        models.Arc('sample collection-9-2', 'sample-0815-T1'),
+        models.Arc('source-0816', 'sample collection-9-3'),
+        models.Arc('sample collection-9-3', 'sample-0816-T1'),
+        models.Arc('source-0817', 'sample collection-9-4'),
+        models.Arc('sample collection-9-4', 'sample-0817-T1'),
     )
     assert expected == study.arcs

--- a/tests/test_parse_study.py
+++ b/tests/test_parse_study.py
@@ -91,7 +91,7 @@ def test_study_row_reader_small_study(
 
     # Create new row reader and check read headers
     row_reader = StudyRowReader.from_stream(investigation, small_study_file)
-    assert 10 == len(row_reader.header)
+    assert 11 == len(row_reader.header)
 
     # Read all rows in study
     rows = list(row_reader.read())
@@ -128,7 +128,8 @@ def test_study_row_reader_small_study(
         'John Doe', (), (), None, None)
     assert expected == first_row[1]
     expected = models.Material(
-        'Sample Name', 'sample-0815-N1', None, (), (), (), None)
+        'Sample Name', 'sample-0815-N1', None,
+        (models.Characteristics('status', '0', None), ), (), (), None)
     assert expected == first_row[2]
 
     assert 3 == len(second_row)
@@ -140,7 +141,8 @@ def test_study_row_reader_small_study(
         'John Doe', (), (), None, None)
     assert expected == second_row[1]
     expected = models.Material(
-        'Sample Name', 'sample-0815-T1', None, (), (), (), None)
+        'Sample Name', 'sample-0815-T1', None,
+        (models.Characteristics('status', '2', None), ), (), (), None)
     assert expected == second_row[2]
 
 
@@ -152,14 +154,14 @@ def test_study_reader_small_study(
 
     # Create new row reader and check read headers
     reader = StudyReader.from_stream(investigation, small_study_file)
-    assert 10 == len(reader.header)
+    assert 11 == len(reader.header)
 
     # Read study
     study = reader.read()
 
     # Check results
     assert str(study.file).endswith('data/i_small/s_small.txt')
-    assert 10 == len(study.header)
+    assert 11 == len(study.header)
     assert 7 == len(study.materials)
     assert 4 == len(study.processes)
     assert 8 == len(study.arcs)
@@ -202,17 +204,22 @@ def test_study_reader_small_study(
     expected = models.Material(
         'Source Name', 'source-0817', None, characteristics3, (), (), None)
     assert expected == study.materials['source-0817']
+
     expected = models.Material(
-        'Sample Name', 'sample-0815-N1', None, (), (), (), None)
+        'Sample Name', 'sample-0815-N1', None,
+        (models.Characteristics('status', '0', None), ), (), (), None)
     assert expected == study.materials['sample-0815-N1']
     expected = models.Material(
-        'Sample Name', 'sample-0815-T1', None, (), (), (), None)
+        'Sample Name', 'sample-0815-T1', None,
+        (models.Characteristics('status', '2', None),), (), (), None)
     assert expected == study.materials['sample-0815-T1']
     expected = models.Material(
-        'Sample Name', 'sample-0816-T1', None, (), (), (), None)
+        'Sample Name', 'sample-0816-T1', None,
+        (models.Characteristics('status', '1', None),), (), (), None)
     assert expected == study.materials['sample-0816-T1']
     expected = models.Material(
-        'Sample Name', 'sample-0817-T1', None, (), (), (), None)
+        'Sample Name', 'sample-0817-T1', None,
+        (models.Characteristics('status', '2', None),), (), (), None)
     assert expected == study.materials['sample-0817-T1']
 
     expected = models.Process(


### PR DESCRIPTION
Ontology references of Units were assigned to the primary annotation (e.g. Characteristic). I'm basically considering Unit as a primary annotation for now to enable ontology annotation. They are still assigned to previous primary annotations, if no Unit is assigned yet or if the previous wasn't a Unit itself. This should cover all cases, but the naming (primary, secondary) is not really explanatory/distinctive any more (maybe we can come up with something better later).