### PR TITLE
Hotfix/empty lines in windows

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## HEAD (unreleased)
+
+- Fixing problem with writing empty lines on Windows (#52).
+
 ## v0.2.0
 
 - Switching to `attrs` instead of using `Namedtuple`.

--- a/altamisa/apps/isatab2isatab.py
+++ b/altamisa/apps/isatab2isatab.py
@@ -92,9 +92,13 @@ def run_reading(args, path_in):
 
 def run_writing(args, path_out, investigation, studies, assays):
     # Write investigation
-    InvestigationWriter.from_stream(
-        investigation, args.output_investigation_file, quote=args.quotes
-    ).write()
+    if args.output_investigation_file.name == "<stdout>":
+        InvestigationWriter.from_stream(
+            investigation, args.output_investigation_file, quote=args.quotes
+        ).write()
+    else:
+        with open(args.output_investigation_file.name, "wt", newline="") as outputf:
+            InvestigationWriter.from_stream(investigation, outputf, quote=args.quotes).write()
 
     # Write studies and assays
     for s, study_info in enumerate(investigation.studies):
@@ -110,11 +114,13 @@ def run_writing(args, path_out, investigation, studies, assays):
                     ).write()
         else:
             if study_info.info.path:
-                with open(os.path.join(path_out, study_info.info.path), "wt") as outputf:
+                with open(
+                    os.path.join(path_out, study_info.info.path), "wt", newline=""
+                ) as outputf:
                     StudyWriter.from_stream(studies[s], outputf, quote=args.quotes).write()
             for a, assay_info in enumerate(study_info.assays):
                 if assay_info.path:
-                    with open(os.path.join(path_out, assay_info.path), "wt") as outputf:
+                    with open(os.path.join(path_out, assay_info.path), "wt", newline="") as outputf:
                         AssayWriter.from_stream(assays[s][a], outputf, quote=args.quotes).write()
 
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -80,7 +80,7 @@ investigation, as files might be overwritten otherwise):
 .. code-block:: python
 
     # Write investigation
-    with open("path/to/output/investigation.txt", "wt") as output_investigation_file:
+    with open("path/to/output/investigation.txt", "wt", newline='') as output_investigation_file:
         InvestigationWriter.from_stream(
             investigation, output_investigation_file, quote=args.quotes
         ).write()
@@ -88,11 +88,11 @@ investigation, as files might be overwritten otherwise):
     # Write studies and assays
     for s, study_info in enumerate(investigation.studies):
         if study_info.info.path:
-            with open(os.path.join(path_out, study_info.info.path), "wt") as outputf:
+            with open(os.path.join(path_out, study_info.info.path), "wt", newline="") as outputf:
                 StudyWriter.from_stream(studies[s], outputf, quote=args.quotes).write()
         for a, assay_info in enumerate(study_info.assays):
             if assay_info.path:
-                with open(os.path.join(path_out, assay_info.path), "wt") as outputf:
+                with open(os.path.join(path_out, assay_info.path), "wt", newline="") as outputf:
                     AssayWriter.from_stream(assays[s][a], outputf, quote=args.quotes).write()
 
 	

--- a/tests/test_write_assay.py
+++ b/tests/test_write_assay.py
@@ -42,7 +42,7 @@ def _parse_write_assert_assay(investigation_file, tmp_path, quote=None, normaliz
             AssayValidator(investigation, study_info, assay_info, assay).validate()
             # Write assay to temporary file
             path_out = tmp_path / assay_info.path
-            with open(path_out, "wt") as file:
+            with open(path_out, "wt", newline="") as file:
                 AssayWriter.from_stream(assay, file, quote=quote).write()
             if normalize:
                 # Read and write assay again
@@ -53,7 +53,7 @@ def _parse_write_assert_assay(investigation_file, tmp_path, quote=None, normaliz
                     ).read()
                 AssayValidator(investigation, study_info, assay_info, assay).validate()
                 path_out = tmp_path / (assay_info.path.name + "_b")
-                with open(path_out, "wt") as file:
+                with open(path_out, "wt", newline="") as file:
                     AssayWriter.from_stream(assay, file, quote=quote).write()
             # Sort and compare input and output
             path_in_s = tmp_path / (assay_info.path.name + ".in.sorted")

--- a/tests/test_write_study.py
+++ b/tests/test_write_study.py
@@ -32,7 +32,7 @@ def _parse_write_assert(investigation_file, tmp_path, quote=None):
         StudyValidator(investigation, study_info, study).validate()
         # Write study to temporary file
         path_out = tmp_path / study_info.info.path
-        with open(path_out, "wt") as file:
+        with open(path_out, "wt", newline="") as file:
             StudyWriter.from_stream(study, file, quote=quote).write()
         # Sort and compare input and output
         path_in_s = tmp_path / (study_info.info.path.name + ".in.sorted")


### PR DESCRIPTION
Had a weird issue with csw.writer double newlines under Windows, resulting in several failing writing tests. Fixed it according to this: https://stackoverflow.com/questions/3191528/csv-in-python-adding-an-extra-carriage-return-on-windows
However, fells more like unsatisfactory workaround, as the issue needs to be handled from outside the API when opening a file. But for now testing under Windows works. I guess beside me developing from time to time under Windows, there won't be any applications of the API under Windows anyways.