### PR TITLE
fix: remove deprecated config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,11 +19,6 @@ select = B,C,E,F,W,T4,B9
 [tool:pytest]
 addopts = --cov=altamisa --cov=tests --cov-report=xml
 testpaths = tests
-pep8ignore =
-    docs/* ALL
-    examples/*.py E501
-    tests/*.py E501
-    vcfpy/*.py F401
 
 [coverage:run]
 omit =


### PR DESCRIPTION
This config option was used by pytest-pep8 which is unmaintained since 2014 and is not used by us any more. Pytest throws a warning about this.