### PR TITLE
fix: Typo in missing STUDY section error msg

### DIFF
--- a/altamisa/isatab/parse_investigation.py
+++ b/altamisa/isatab/parse_investigation.py
@@ -361,7 +361,7 @@ class InvestigationReader:
             line = self._read_next_line()
             if not line[0] == investigation_headers.STUDY:  # pragma: no cover
                 tpl = "Expected {} but got {}"
-                msg = tpl.format(investigation_headers.INVESTIGATION, line)
+                msg = tpl.format(investigation_headers.STUDY, line)
                 raise ParseIsatabException(msg)
             # Read the other lines in this section.
             section, comment_keys = self._read_single_column_section(


### PR DESCRIPTION
This looks like a typo. If no STUDY section is found, the error message should not ask for the INVESTIGATION section.