### PR TITLE
chore: Convert str.format to f-strings

### DIFF
--- a/altamisa/apps/isatab2dot.py
+++ b/altamisa/apps/isatab2dot.py
@@ -34,18 +34,15 @@ def print_dot(
 ):
     print(indent + "/* materials */", file=outf)
     for name, mat in obj.materials.items():
-        label = json.dumps("{}:\n{}\n({})".format(mat.type, mat.name if mat.name else "-", name))
+        label = json.dumps(f"{mat.type}:\n{mat.name if mat.name else '-'}\n({name})")
         print(
-            "{}{} [label={},shape={},color={},fontcolor={}]".format(
-                indent, json.dumps(name), label, mat_shape, mat_color, mat_color
-            ),
+            f"{indent}{json.dumps(name)} [label={label},shape={mat_shape},color={mat_color},fontcolor={mat_color}]",
             file=outf,
         )
     print(indent + "/* processes */", file=outf)
     for name, proc in obj.processes.items():
         label = json.dumps(
-            "{}:\n{}\n{}\n({})".format(
-                "Process",
+            "Process:\n{}\n{}\n({})".format(
                 proc.protocol_ref if proc.protocol_ref else "-",
                 proc.name if proc.name else "-",
                 name,
@@ -59,7 +56,7 @@ def print_dot(
         )
     print(indent + "/* arcs */", file=outf)
     for arc in obj.arcs:
-        print("{}{} -> {};".format(indent, json.dumps(arc.tail), json.dumps(arc.head)), file=outf)
+        print(f"{indent}{json.dumps(arc.tail)} -> {json.dumps(arc.head)};", file=outf)
 
 
 def run(args: Arguments):
@@ -79,27 +76,25 @@ def run(args: Arguments):
 
         for s, study_info in enumerate(investigation.studies):
             if not study_info.info.path:
-                print("  /* no file for study {} */".format(s + 1), file=output_file)
+                print(f"  /* no file for study {s + 1} */", file=output_file)
                 continue
             with open(os.path.join(path, study_info.info.path), "rt") as inputf:
-                study = StudyReader.from_stream("S{}".format(s + 1), inputf).read()
-            print("  /* study {} */".format(study_info.info.path), file=output_file)
-            print("  subgraph clusterStudy{} {{".format(s), file=output_file)
-            print('    label = "Study: {}"'.format(study_info.info.path), file=output_file)
+                study = StudyReader.from_stream(f"S{s + 1}", inputf).read()
+            print(f"  /* study {study_info.info.path} */", file=output_file)
+            print(f"  subgraph clusterStudy{s} {{", file=output_file)
+            print(f'    label = "Study: {study_info.info.path}"', file=output_file)
             print_dot(study, output_file)
             print("  }", file=output_file)
 
             for a, assay_info in enumerate(study_info.assays):
                 if not assay_info.path:
-                    print("  /* no file for assay {} */".format(a + 1), file=output_file)
+                    print(f"  /* no file for assay {a + 1} */", file=output_file)
                     continue
                 with open(os.path.join(path, assay_info.path), "rt") as inputf:
-                    assay = AssayReader.from_stream(
-                        "S{}".format(s + 1), "A{}".format(a + 1), inputf
-                    ).read()
-                print("  /* assay {} */".format(assay_info.path), file=output_file)
-                print("  subgraph clusterAssayS{}A{} {{".format(s, a), file=output_file)
-                print('    label = "Assay: {}"'.format(assay_info.path), file=output_file)
+                    assay = AssayReader.from_stream(f"S{s + 1}", f"A{a + 1}", inputf).read()
+                print(f"  /* assay {assay_info.path} */", file=output_file)
+                print(f"  subgraph clusterAssayS{s}A{a} {{", file=output_file)
+                print(f'    label = "Assay: {assay_info.path}"', file=output_file)
                 print_dot(assay, output_file)
                 print("  }", file=output_file)
 

--- a/altamisa/apps/isatab2isatab.py
+++ b/altamisa/apps/isatab2isatab.py
@@ -61,8 +61,7 @@ def run_warnings_caught(args: Arguments):
     path_in = os.path.realpath(os.path.dirname(args.input_investigation_file))
     path_out = os.path.realpath(os.path.dirname(args.output_investigation_file))
     if path_in == path_out:
-        tpl = "Can't output ISA-tab files to same directory as as input: {} == {}"
-        msg = tpl.format(path_in, path_out)
+        msg = f"Can't output ISA-tab files to same directory as as input: {path_in} == {path_out}"
         raise IsaException(msg)
 
     with ExitStack() as stack:
@@ -98,15 +97,13 @@ def run_reading(
     for s, study_info in enumerate(investigation.studies):
         if study_info.info.path:
             with open(os.path.join(path_in, study_info.info.path), "rt") as inputf:
-                studies[s] = StudyReader.from_stream("S{}".format(s + 1), inputf).read()
+                studies[s] = StudyReader.from_stream(f"S{s + 1}", inputf).read()
         if study_info.assays:
             assays[s] = {}
         for a, assay_info in enumerate(study_info.assays):
             if assay_info.path:
                 with open(os.path.join(path_in, assay_info.path), "rt") as inputf:
-                    assays[s][a] = AssayReader.from_stream(
-                        "S{}".format(s + 1), "A{}".format(a + 1), inputf
-                    ).read()
+                    assays[s][a] = AssayReader.from_stream(f"S{s + 1}", f"A{a + 1}", inputf).read()
 
     # Validate studies and assays
     for s, study_info in enumerate(investigation.studies):

--- a/altamisa/apps/isatab_validate.py
+++ b/altamisa/apps/isatab_validate.py
@@ -82,15 +82,13 @@ def run_warnings_caught(args: Arguments):
     for s, study_info in enumerate(investigation.studies):
         if study_info.info.path:
             with open(os.path.join(path_in, study_info.info.path), "rt") as inputf:
-                studies[s] = StudyReader.from_stream("S{}".format(s + 1), inputf).read()
+                studies[s] = StudyReader.from_stream(f"S{s + 1}", inputf).read()
         if study_info.assays:
             assays[s] = {}
         for a, assay_info in enumerate(study_info.assays):
             if assay_info.path:
                 with open(os.path.join(path_in, assay_info.path), "rt") as inputf:
-                    assays[s][a] = AssayReader.from_stream(
-                        "S{}".format(s + 1), "A{}".format(a + 1), inputf
-                    ).read()
+                    assays[s][a] = AssayReader.from_stream(f"S{s + 1}", f"A{a + 1}", inputf).read()
 
     # Validate studies and assays
     for s, study_info in enumerate(investigation.studies):

--- a/altamisa/isatab/headers.py
+++ b/altamisa/isatab/headers.py
@@ -446,8 +446,7 @@ class HeaderParserBase:
                         raise ParseIsatabException(msg)
                     return self._parse_labeled_column_header(val, label, type_)
         # None of the if-statements above was taken
-        tpl = 'Header "{}" unknown, processing unclear'
-        msg = tpl.format(val)
+        msg = f'Header "{val}" unknown, processing unclear'
         raise ParseIsatabException(msg)
 
     def _parse_term_source_ref(self):
@@ -471,8 +470,7 @@ class HeaderParserBase:
     def _parse_labeled_column_header(self, val, key, type_):
         tok = val[len(key) :]  # strip '^{key}'
         if not tok or tok[0] != "[" or tok[-1] != "]":
-            tpl = "Problem parsing labeled header {}"
-            msg = tpl.format(val)
+            msg = f"Problem parsing labeled header {val}"
             raise ParseIsatabException(msg)
         self.col_no += 1
         return type_(self.col_no - 1, tok[1:-1])

--- a/altamisa/isatab/helpers.py
+++ b/altamisa/isatab/helpers.py
@@ -21,7 +21,6 @@ def list_strip(line: List[str]) -> List[str]:
     """Remove trailing space from strings in a list (e.g. a csv line)"""
     new_line = [field.strip() for field in line]
     if new_line != line:
-        tpl = "Removed trailing whitespaces in fields of line: {}"
-        msg = tpl.format(line)
+        msg = f"Removed trailing whitespaces in fields of line: {line}"
         warnings.warn(msg, ParseIsatabWarning)
     return new_line

--- a/altamisa/isatab/models.py
+++ b/altamisa/isatab/models.py
@@ -509,7 +509,7 @@ class Arc:
         elif idx == 1:
             return self.head
         else:
-            raise IndexError("Invalid index: %d" % idx)  # pragma: no cover
+            raise IndexError(f"Invalid index: {idx}")  # pragma: no cover
 
 
 @attr.s(auto_attribs=True, frozen=True)

--- a/altamisa/isatab/parse_assay_study.py
+++ b/altamisa/isatab/parse_assay_study.py
@@ -130,8 +130,10 @@ class _NodeBuilderBase(Generic[TNode]):
                 header.column_type not in self.name_headers
                 and header.column_type not in self.allowed_column_types
             ):
-                tpl = 'Invalid column type occured "{}" not in {}'
-                msg = tpl.format(header.column_type, self.allowed_column_types)
+                msg = (
+                    "Invalid column type occured "
+                    f'"{header.column_type}" not in {self.allowed_column_types}'
+                )
                 raise ParseIsatabException(msg)
             # Most headers are not secondary, so make this the default state.
             is_secondary = False
@@ -206,7 +208,7 @@ class _NodeBuilderBase(Generic[TNode]):
                 ):  # pragma: no cover
                     tpl = (
                         "Ontologies not supported for primary annotation "
-                        "'{}' (in col {}).".format(prev.column_type, "{}")
+                        f"'{prev.column_type}' (in col {{}})."
                     )
                 elif prev.term_source_ref_header:  # pragma: no cover
                     tpl = 'Seen "Term Source REF" header for same entity ' "in col {}"
@@ -232,8 +234,7 @@ class _NodeBuilderBase(Generic[TNode]):
 
     @staticmethod
     def _raise_seen_before(name, col_no):  # pragma: no cover
-        tpl = 'Seen "{}" header for same entity in col {}'
-        msg = tpl.format(name, col_no)
+        msg = f'Seen "{name}" header for same entity in col {col_no}'
         raise ParseIsatabException(msg)
 
     def _build_complex(
@@ -256,7 +257,7 @@ class _NodeBuilderBase(Generic[TNode]):
         unit = self._build_freetext_or_term_ref(header.unit_header, line)
         if unit is not None and not isinstance(unit, (str, models.OntologyTermRef)):
             raise ParseIsatabException(
-                "Unit must be a string or an OntologyTermRef, not {}".format(type(unit))
+                f"Unit must be a string or an OntologyTermRef, not {type(unit)}"
             )
         # Then, constructing ``klass`` is easy
         return klass(header.label, value, unit)
@@ -284,11 +285,10 @@ class _NodeBuilderBase(Generic[TNode]):
                     ]
                     return term_refs
                 else:  # pragma: no cover
-                    tpl = (
+                    msg = (
                         "Irregular numbers of fields in ontology term columns"
-                        "(i.e. ';'-separated fields): {}"
+                        f"(i.e. ';'-separated fields): {line[header.col_no : header2.col_no + 2]}"
                     )
-                    msg = tpl.format(line[header.col_no : header2.col_no + 2])
                     raise ParseIsatabException(msg)
 
             # Else, just create single ontology term references
@@ -348,24 +348,22 @@ class _MaterialBuilder(_NodeBuilderBase[models.Material]):
         # First, build the individual components
         if not self.name_header:
             raise ParseIsatabException(
-                "No name header found for material found for file {}".format(self.filename)
+                f"No name header found for material found for file {self.filename}"
             )
         type_ = self.name_header.column_type
-        assay_id = "-{}".format(self.assay_id) if self.assay_id else ""
+        assay_id = f"-{self.assay_id}" if self.assay_id else ""
         name = line[self.name_header.col_no]
         if name:
             # make material/data names unique by column
             if self.name_header.column_type == table_headers.SOURCE_NAME:
-                unique_name = "{}-{}-{}".format(self.study_id, "source", name)
+                unique_name = f"{self.study_id}-source-{name}"
             elif self.name_header.column_type == table_headers.SAMPLE_NAME:
                 # use static column identifier "sample-", since the same
                 # samples occur in different columns in study and assay
-                unique_name = "{}-{}-{}".format(self.study_id, "sample", name)
+                unique_name = f"{self.study_id}-sample-{name}"
             else:
                 # anything else gets the column id
-                unique_name = "{}{}-{}-COL{}".format(
-                    self.study_id, assay_id, name, self.name_header.col_no + 1
-                )
+                unique_name = f"{self.study_id}{assay_id}-{name}-COL{self.name_header.col_no + 1}"
         else:
             name_val = "{}{}-{} {}-{}-{}".format(
                 self.study_id,
@@ -434,8 +432,7 @@ class _ProcessBuilder(_NodeBuilderBase[models.Process]):
                 try:
                     date = datetime.strptime(line[self.date_header.col_no], "%Y-%m-%d").date()
                 except ValueError as e:  # pragma: no cover
-                    tpl = 'Invalid ISO8601 date "{}"'  # pragma: no cover
-                    msg = tpl.format(line[self.date_header.col_no])
+                    msg = f'Invalid ISO8601 date "{line[self.date_header.col_no]}"'  # pragma: no cover
                     raise ParseIsatabException(msg) from e
             else:
                 date = ""
@@ -479,14 +476,11 @@ class _ProcessBuilder(_NodeBuilderBase[models.Process]):
     ) -> Tuple[str, Union[models.AnnotatedStr, str], Optional[str], Optional[str]]:
         # At least one of these headers has to be specified
         if not self.name_header and not self.protocol_ref_header:  # pragma: no cover
-            raise ParseIsatabException(
-                "No protocol reference header found for process found for file {}".format(
-                    self.filename
-                )
-            )
+            msg = f"No protocol reference header found for process found for file {self.filename}"
+            raise ParseIsatabException(msg)
         # Perform case distinction on which case is actually true
         counter_value = self._next_counter()
-        assay_id = "-{}".format(self.assay_id) if self.assay_id else ""
+        assay_id = f"-{self.assay_id}" if self.assay_id else ""
         name = None
         name_type = None
         if not self.name_header:  # and self.protocol_ref_header:
@@ -509,9 +503,7 @@ class _ProcessBuilder(_NodeBuilderBase[models.Process]):
             name = line[self.name_header.col_no]
             name_type = self.name_header.column_type
             if name:  # Use name if available
-                unique_name = "{}{}-{}-{}".format(
-                    self.study_id, assay_id, name, self.name_header.col_no + 1
-                )
+                unique_name = f"{self.study_id}{assay_id}-{name}-{self.name_header.col_no + 1}"
             else:  # Empty!  # pragma: no cover
                 name_val = "{}{}-{} {}-{}-{}".format(
                     self.study_id,
@@ -527,9 +519,7 @@ class _ProcessBuilder(_NodeBuilderBase[models.Process]):
             name = line[self.name_header.col_no]
             name_type = self.name_header.column_type
             if name:
-                unique_name = "{}{}-{}-{}".format(
-                    self.study_id, assay_id, name, self.name_header.col_no + 1
-                )
+                unique_name = f"{self.study_id}{assay_id}-{name}-{self.name_header.col_no + 1}"
             else:
                 name_val = "{}{}-{}-{}-{}".format(
                     self.study_id,
@@ -544,7 +534,7 @@ class _ProcessBuilder(_NodeBuilderBase[models.Process]):
                 tpl = "Missing protocol reference in column {} of file {} "
                 msg = tpl.format(self.protocol_ref_header.col_no + 1, self.filename)
             else:
-                msg = "Missing protocol reference in file {}".format(self.filename)
+                msg = f"Missing protocol reference in file {self.filename}"
             raise ParseIsatabException(msg)
         return protocol_ref, unique_name, name, name_type
 
@@ -596,16 +586,16 @@ class _RowBuilderBase:
         ]
         header = [h for h in self.header[start:end] if h.column_type in column_types_to_check]
         names = [
-            "{}[{}]".format(h.column_type, h.label)
-            if isinstance(h, LabeledColumnHeader)
-            else h.column_type
+            f"{h.column_type}[{h.label}]" if isinstance(h, LabeledColumnHeader) else h.column_type
             for h in header
         ]
         duplicates = set([c for c in names if names.count(c) > 1])
         if duplicates:
-            assay = " assay {}".format(self.assay_id) if self.assay_id else ""
-            tpl = "Found duplicated column types in header of study {}{}: {}"
-            msg = tpl.format(self.study_id, assay, ", ".join(duplicates))
+            assay = f" assay {self.assay_id}" if self.assay_id else ""
+            msg = (
+                "Found duplicated column types in header of study "
+                f"{self.study_id}{assay}: {', '.join(duplicates)}"
+            )
             raise ParseIsatabException(msg)
 
     def _make_breaks(self):
@@ -768,11 +758,11 @@ class _AssayAndStudyBuilder:
                     if (
                         entry.unique_name in processes and entry != processes[entry.unique_name]
                     ):  # pragma: no cover
-                        tpl = (
+                        msg = (
                             "Found processes with same name but different "
-                            "annotation:\nprocess 1: {}\nprocess 2: {}"
+                            f"annotation:\nprocess 1: {entry}\n"
+                            f"process 2: {processes[entry.unique_name]}"
                         )
-                        msg = tpl.format(entry, processes[entry.unique_name])
                         raise ParseIsatabException(msg)
                     processes[entry.unique_name] = entry
                 else:
@@ -780,11 +770,11 @@ class _AssayAndStudyBuilder:
                     if (
                         entry.unique_name in materials and entry != materials[entry.unique_name]
                     ):  # pragma: no cover
-                        tpl = (
+                        msg = (
                             "Found materials with same name but different "
-                            "annotation:\nmaterial 1: {}\nmaterial 2: {}"
+                            f"annotation:\nmaterial 1: {entry}\n"
+                            f"material 2: {materials[entry.unique_name]}"
                         )
-                        msg = tpl.format(entry, materials[entry.unique_name])
                         raise ParseIsatabException(msg)
                     materials[entry.unique_name] = entry
                 # Collect arc

--- a/altamisa/isatab/parse_investigation.py
+++ b/altamisa/isatab/parse_investigation.py
@@ -25,8 +25,7 @@ def _parse_comments(section, comment_keys, i=None):
         # key might start with "Comment[" but NOT "Comment ["
         tok = val[len("Comment") :]
         if not tok or tok[0] != "[" or tok[-1] != "]":  # pragma: no cover
-            tpl = 'Problem parsing comment header "{}"'
-            msg = tpl.format(val)
+            msg = f'Problem parsing comment header "{val}"'
             raise ParseIsatabException(msg)
         return tok[1:-1]
 
@@ -56,8 +55,7 @@ def _split_study_protocols_parameters(
         )
         raise ParseIsatabException(msg)
     if len(names) > len(set(names)):  # pragma: no cover
-        tpl = "Repeated protocol parameter; found: {}"
-        msg = tpl.format(names)
+        msg = f"Repeated protocol parameter; found: {names}"
         raise ParseIsatabException(msg)
     for name, acc, src in zip(names, name_term_accs, name_term_srcs):
         if any((name, acc, src)):  # skips empty parameters
@@ -88,15 +86,13 @@ def _split_study_protocols_components(
         )
         raise ParseIsatabException(msg)
     if len(names) > len(set(names)):  # pragma: no cover
-        tpl = "Repeated protocol components; found: {}"
-        msg = tpl.format(names)
+        msg = f"Repeated protocol components; found: {names}"
         raise ParseIsatabException(msg)
     for name, ctype, acc, src in zip(
         names, types, type_term_accs, type_term_srcs
     ):  # pragma: no cover
         if not name and any((ctype, acc, src)):
-            tpl = "Missing protocol component name; " 'found: "{}", "{}", "{}", "{}"'
-            msg = tpl.format(name, ctype, acc, src)
+            msg = f'Missing protocol component name; found: "{name}", "{ctype}", "{acc}", "{src}"'
             raise ParseIsatabException(msg)
         if any((name, ctype, acc, src)):  # skips empty components
             yield models.ProtocolComponentInfo(name, models.OntologyTermRef(ctype, acc, src))
@@ -192,18 +188,15 @@ class InvestigationReader:
             if key.startswith("Comment"):
                 comment_keys.append(key)
             elif key not in ref_keys:  # pragma: no cover
-                tpl = "Line must start with one of {} but is {}"
-                msg = tpl.format(ref_keys, line)
+                msg = f"Line must start with one of {ref_keys} but is {line}"
                 raise ParseIsatabException(msg)
             if key in section:  # pragma: no cover
-                tpl = 'Key {} repeated, previous value "{}"'
-                msg = tpl.format(key, section[key])
+                msg = f'Key {key} repeated, previous value "{section[key]}"'
                 raise ParseIsatabException(msg)
             section[key] = line[1:]
         # Check that all keys are given and all contain the same number of entries
         if len(section) != len(ref_keys) + len(comment_keys):  # pragma: no cover
-            tpl = "Missing entries in section {}; only found: {}"
-            msg = tpl.format(section_name, list(sorted(section)))
+            msg = f"Missing entries in section {section_name}; only found: {list(sorted(section))}"
             raise ParseIsatabException(msg)  # TODO: should be warning?
         if not len(set([len(v) for v in section.values()])) == 1:  # pragma: no cover
             lengths = "\n".join(
@@ -224,26 +217,22 @@ class InvestigationReader:
             if line is None:
                 break
             if len(line) > 2:  # pragma: no cover
-                tpl = "Line {} contains more than one value: {}"
-                msg = tpl.format(line[0], line[1:])
+                msg = f"Line {line[0]} contains more than one value: {line[1:]}"
                 raise ParseIsatabException(msg)
             key = line[0]
             if key.startswith("Comment"):
                 comment_keys.append(key)
             elif key not in ref_keys:  # pragma: no cover
-                tpl = "Line must start with one of {} but is {}"
-                msg = tpl.format(ref_keys, line)
+                msg = f"Line must start with one of {ref_keys} but is {line}"
                 raise ParseIsatabException(msg)
             if key in section:  # pragma: no cover
-                tpl = 'Key {} repeated, previous value "{}"'
-                msg = tpl.format(key, section[key])
+                msg = f'Key {key} repeated, previous value "{section[key]}"'
                 raise ParseIsatabException(msg)
             # read value if field is available, empty string else
             section[key] = line[1] if len(line) > 1 else ""
         # Check that all keys are given
         if len(section) != len(ref_keys) + len(comment_keys):  # pragma: no cover
-            tpl = "Missing entries in section {}; only found: {}"
-            msg = tpl.format(section_name, list(sorted(section)))
+            msg = f"Missing entries in section {section_name}; only found: {list(sorted(section))}"
             raise ParseIsatabException(msg)  # TODO: should be warning?
         return section, comment_keys
 
@@ -253,8 +242,7 @@ class InvestigationReader:
         if (
             not line or not line[0] == investigation_headers.ONTOLOGY_SOURCE_REFERENCE
         ):  # pragma: no cover
-            tpl = "Expected {} but got {}"
-            msg = tpl.format(investigation_headers.ONTOLOGY_SOURCE_REFERENCE, line)
+            msg = f"Expected {investigation_headers.ONTOLOGY_SOURCE_REFERENCE} but got {line}"
             raise ParseIsatabException(msg)
         # Read the other four lines in this section.
         section, comment_keys = self._read_multi_column_section(
@@ -269,8 +257,7 @@ class InvestigationReader:
             # If ontology source is empty, skip it
             # (since ISAcreator always adds a last empty ontology column)
             if not any((name, file_, version, desc, any(comments))):
-                tpl = "Skipping empty ontology source: {}, {}, {}, {}"
-                msg = tpl.format(name, file_, version, desc)
+                msg = f"Skipping empty ontology source: {name}, {file_}, {version}, {desc}"
                 warnings.warn(msg, ParseIsatabWarning)
                 continue
             yield models.OntologyRef(name, file_, version, desc, comments, list(section.keys()))
@@ -279,8 +266,7 @@ class InvestigationReader:
         # Read INVESTIGATION header
         line = self._read_next_line()
         if not line or not line[0] == investigation_headers.INVESTIGATION:  # pragma: no cover
-            tpl = "Expected {} but got {}"
-            msg = tpl.format(investigation_headers.INVESTIGATION, line)
+            msg = f"Expected {investigation_headers.INVESTIGATION} but got {line}"
             raise ParseIsatabException(msg)
         # Read the other lines in this section.
         section, comment_keys = self._read_single_column_section(
@@ -308,8 +294,7 @@ class InvestigationReader:
         if (
             not line or not line[0] == investigation_headers.INVESTIGATION_PUBLICATIONS
         ):  # pragma: no cover
-            tpl = "Expected {} but got {}"
-            msg = tpl.format(investigation_headers.INVESTIGATION_PUBLICATIONS, line)
+            msg = "Expected {investigation_headers.INVESTIGATION_PUBLICATIONS} but got {line}"
             raise ParseIsatabException(msg)
         # Read the other lines in this section.
         section, comment_keys = self._read_multi_column_section(
@@ -335,8 +320,7 @@ class InvestigationReader:
         if (
             not line or not line[0] == investigation_headers.INVESTIGATION_CONTACTS
         ):  # pragma: no cover
-            tpl = "Expected {} but got {}"
-            msg = tpl.format(investigation_headers.INVESTIGATION_CONTACTS, line)
+            msg = f"Expected {investigation_headers.INVESTIGATION_CONTACTS} but got {line}"
             raise ParseIsatabException(msg)
         # Read the other lines in this section.
         section, comment_keys = self._read_multi_column_section(
@@ -383,8 +367,7 @@ class InvestigationReader:
             # Read STUDY header
             line = self._read_next_line()
             if not line or not line[0] == investigation_headers.STUDY:  # pragma: no cover
-                tpl = "Expected {} but got {}"
-                msg = tpl.format(investigation_headers.STUDY, line)
+                msg = f"Expected {investigation_headers.STUDY} but got {line}"
                 raise ParseIsatabException(msg)
             # Read the other lines in this section.
             section, comment_keys = self._read_single_column_section(
@@ -425,8 +408,7 @@ class InvestigationReader:
         if (
             not line or not line[0] == investigation_headers.STUDY_DESIGN_DESCRIPTORS
         ):  # pragma: no cover
-            tpl = "Expected {} but got {}"
-            msg = tpl.format(investigation_headers.STUDY_DESIGN_DESCRIPTORS, line)
+            msg = f"Expected {investigation_headers.STUDY_DESIGN_DESCRIPTORS} but got {line}"
             raise ParseIsatabException(msg)
         # Read the other lines in this section.
         section, comment_keys = self._read_multi_column_section(
@@ -445,8 +427,7 @@ class InvestigationReader:
         # Read STUDY PUBLICATIONS header
         line = self._read_next_line()
         if not line or not line[0] == investigation_headers.STUDY_PUBLICATIONS:  # pragma: no cover
-            tpl = "Expected {} but got {}"
-            msg = tpl.format(investigation_headers.STUDY_PUBLICATIONS, line)
+            msg = f"Expected {investigation_headers.STUDY_PUBLICATIONS} but got {line}"
             raise ParseIsatabException(msg)
         # Read the other lines in this section.
         section, comment_keys = self._read_multi_column_section(
@@ -470,8 +451,7 @@ class InvestigationReader:
         # Read STUDY FACTORS header
         line = self._read_next_line()
         if not line or not line[0] == investigation_headers.STUDY_FACTORS:  # pragma: no cover
-            tpl = "Expected {} but got {}"
-            msg = tpl.format(investigation_headers.STUDY_FACTORS, line)
+            msg = f"Expected {investigation_headers.STUDY_FACTORS} but got {line}"
             raise ParseIsatabException(msg)
         # Read the other lines in this section.
         section, comment_keys = self._read_multi_column_section(
@@ -490,8 +470,7 @@ class InvestigationReader:
         # Read STUDY ASSAYS header
         line = self._read_next_line()
         if not line or not line[0] == investigation_headers.STUDY_ASSAYS:  # pragma: no cover
-            tpl = "Expected {} but got {}"
-            msg = tpl.format(investigation_headers.STUDY_ASSAYS, line)
+            msg = f"Expected {investigation_headers.STUDY_ASSAYS} but got {line}"
             raise ParseIsatabException(msg)
         # Read the other lines in this section.
         section, comment_keys = self._read_multi_column_section(
@@ -543,8 +522,7 @@ class InvestigationReader:
         # Read STUDY PROTOCOLS header
         line = self._read_next_line()
         if not line or not line[0] == investigation_headers.STUDY_PROTOCOLS:  # pragma: no cover
-            tpl = "Expected {} but got {}"
-            msg = tpl.format(investigation_headers.STUDY_PROTOCOLS, line)
+            msg = f"Expected {investigation_headers.STUDY_PROTOCOLS} but got {line}"
             raise ParseIsatabException(msg)
         # Read the other lines in this section.
         section, comment_keys = self._read_multi_column_section(
@@ -608,8 +586,7 @@ class InvestigationReader:
         # Read STUDY CONTACTS header
         line = self._read_next_line()
         if not line or not line[0] == investigation_headers.STUDY_CONTACTS:  # pragma: no cover
-            tpl = "Expected {} but got {}"
-            msg = tpl.format(investigation_headers.STUDY_CONTACTS, line)
+            msg = f"Expected {investigation_headers.STUDY_CONTACTS} but got {line}"
             raise ParseIsatabException(msg)
         # Read the other lines in this section.
         section, comment_keys = self._read_multi_column_section(

--- a/altamisa/isatab/parse_investigation.py
+++ b/altamisa/isatab/parse_investigation.py
@@ -294,7 +294,7 @@ class InvestigationReader:
         if (
             not line or not line[0] == investigation_headers.INVESTIGATION_PUBLICATIONS
         ):  # pragma: no cover
-            msg = "Expected {investigation_headers.INVESTIGATION_PUBLICATIONS} but got {line}"
+            msg = f"Expected {investigation_headers.INVESTIGATION_PUBLICATIONS} but got {line}"
             raise ParseIsatabException(msg)
         # Read the other lines in this section.
         section, comment_keys = self._read_multi_column_section(

--- a/altamisa/isatab/validate_investigation.py
+++ b/altamisa/isatab/validate_investigation.py
@@ -35,32 +35,28 @@ PMID_PATTERN = re.compile("^\\d+$")
 def _validate_mail_address(mail_address: str) -> None:
     """Helper function to validate mail strings"""
     if mail_address and not MAIL_PATTERN.match(mail_address):
-        tpl = "Invalid mail address: {}"
-        msg = tpl.format(mail_address)
+        msg = f"Invalid mail address: {mail_address}"
         warnings.warn(msg, AdvisoryIsaValidationWarning)
 
 
 def _validate_phone_number(phone_number: str) -> None:
     """Helper function to validate phone/fax number strings"""
     if phone_number and not PHONE_PATTERN.match(phone_number):
-        tpl = "Invalid phone/fax number: {}"
-        msg = tpl.format(phone_number)
+        msg = f"Invalid phone/fax number: {phone_number}"
         warnings.warn(msg, AdvisoryIsaValidationWarning)
 
 
 def _validate_doi(doi: str) -> None:
     """Helper function to validate doi strings"""
     if doi and not DOI_PATTERN.match(doi):
-        tpl = "Invalid doi string: {}"
-        msg = tpl.format(doi)
+        msg = f"Invalid doi string: {doi}"
         warnings.warn(msg, AdvisoryIsaValidationWarning)
 
 
 def _validate_pubmed_id(pubmed_id: str) -> None:
     """Helper function to validate pubmed id strings"""
     if pubmed_id and not PMID_PATTERN.match(pubmed_id):
-        tpl = "Invalid pubmed_id string: {}"
-        msg = tpl.format(pubmed_id)
+        msg = f"Invalid pubmed_id string: {pubmed_id}"
         warnings.warn(msg, AdvisoryIsaValidationWarning)
 
 
@@ -92,16 +88,16 @@ class InvestigationValidator:
         for source in self._investigation.ontology_source_refs.values():
             # Check that ontology sources are complete
             if not all((source.name, source.file, source.version, source.description)):
-                tpl = "Incomplete ontology source; found: {}, {}, {}, {}, {}"
-                msg = tpl.format(
-                    source.name, source.file, source.version, source.description, source.comments
+                msg = (
+                    f"Incomplete ontology source; found: {source.name}, {source.file}, "
+                    f"{source.version}, {source.description}, {source.comments}"
                 )
                 warnings.warn(msg, CriticalIsaValidationWarning)
             # Check that ontology source names contain no whitespaces
             if re.search("\\s", source.name):
-                tpl = "Ontology source name including whitespace(s); found: {}, {}, {}, {}, {}"
-                msg = tpl.format(
-                    source.name, source.file, source.version, source.description, source.comments
+                msg = (
+                    f"Ontology source name including whitespace(s); found: {source.name}, "
+                    f"{source.file}, {source.version}, {source.description}, {source.comments}"
                 )
                 warnings.warn(msg, AdvisoryIsaValidationWarning)
 
@@ -117,71 +113,69 @@ class InvestigationValidator:
         # (https://isa-specs.readthedocs.io/en/latest/isatab.html#investigation-section)
         if len(self._investigation.studies) == 1:
             if any((info.title, info.description, info.submission_date, info.public_release_date)):
-                tpl = (
-                    "Investigation with only one study contains metadata:\n\tID:\t{}\n\tTitle:\t"
-                    "{}\n\tPath:\t{}\n\tSubmission Date:\t{}\n\tPublic Release Date:\t{"
-                    "}\n\tPrefer recording metadata in the study section."
-                )
-                msg = tpl.format(
-                    info.identifier,
-                    info.title,
-                    info.path or "",
-                    info.description,
-                    info.submission_date,
-                    info.public_release_date,
+                msg = (
+                    "Investigation with only one study contains metadata:\n"
+                    f"\tID:\t{info.identifier}\n\tTitle:\t{info.title}\n"
+                    f"\tPath:\t{info.path or ''}\n\tDescription:\t{info.description}\n"
+                    f"\tSubmission Date:\t{info.submission_date}\n"
+                    f"\tPublic Release Date:\t{info.public_release_date}\n"
+                    "\tPrefer recording metadata in the study section."
                 )
                 warnings.warn(msg, ModerateIsaValidationWarning)
         # If more than one study is available, investigation should at least contain an id and title
         else:
             # Validate availability of investigation identifier
             if not info.identifier:
-                tpl = "Investigation without identifier:\nTitle:\t{}\nPath:\t{}"
-                msg = tpl.format(info.title, info.path or "")
+                msg = (
+                    "Investigation without identifier:\n"
+                    f"Title:\t{info.title}\nPath:\t{info.path or ''}"
+                )
                 warnings.warn(msg, ModerateIsaValidationWarning)
             # Validate availability of investigation title
             if not info.title:
-                tpl = "Investigation without title:\nID:\t{}\nPath:\t{}"
-                msg = tpl.format(info.identifier, info.path or "")
+                msg = (
+                    "Investigation without title:\n"
+                    f"ID:\t{info.identifier}\nPath:\t{info.path or ''}"
+                )
                 warnings.warn(msg, ModerateIsaValidationWarning)
 
     def _validate_studies(self):
         # Check if any study exists
         if not self._investigation.studies:
-            tpl = "No studies declared in investigation: {}"
-            msg = tpl.format(self._investigation.info.path)
+            msg = f"No studies declared in investigation: {self._investigation.info.path}"
             warnings.warn(msg, CriticalIsaValidationWarning)
             return
         for study in self._investigation.studies:
             # Validate availability of minimal study information (ids, paths, titles)
             if not (study.info.identifier and study.info.path):
-                tpl = (
+                msg = (
                     "Study with incomplete minimal information (ID and path):"
-                    "\nID:\t{}\nTitle:\t{}\nPath:\t{}"
+                    f"\nID:\t{study.info.identifier}\nTitle:\t{study.info.title}\n"
+                    f"Path:\t{study.info.path or ''}"
                 )
-                msg = tpl.format(study.info.identifier, study.info.title, study.info.path or "")
                 warnings.warn(msg, CriticalIsaValidationWarning)
             if not study.info.title:
-                tpl = "Study without title:\nID:\t{}\nTitle:\t{}\nPath:\t{}"
-                msg = tpl.format(study.info.identifier, study.info.title, study.info.path or "")
+                msg = (
+                    "Study without title:\n"
+                    f"ID:\t{study.info.identifier}\nTitle:\t{study.info.title}\n"
+                    f"Path:\t{study.info.path or ''}"
+                )
                 warnings.warn(msg, ModerateIsaValidationWarning)
             # Assure distinct studies, i.e. unique ids, paths and preferably titles
             if study.info.identifier in self._study_ids:
-                tpl = "Study identifier used more than once: {}"
-                msg = tpl.format(study.info.identifier)
+                msg = f"Study identifier used more than once: {study.info.identifier}"
                 warnings.warn(msg, CriticalIsaValidationWarning)
             else:
                 self._study_ids.add(study.info.identifier)
             if study.info.path:
                 if study.info.path in self._study_paths:
-                    tpl = "Study path used more than once: {}"
-                    msg = tpl.format(study.info.path or "")
+                    msg = f"Study path used more than once: {study.info.path or ''}"
                     warnings.warn(msg, CriticalIsaValidationWarning)
                 else:
                     self._study_paths.add(study.info.path)
             if study.info.title:
                 if study.info.title in self._study_titles:
-                    tpl = "Study title used more than once: {}"
-                    msg = tpl.format(study.info.title)
+                    msg = f"Study title used more than once: {study.info.title}"
                     warnings.warn(msg, ModerateIsaValidationWarning)
                 else:
                     self._study_titles.add(study.info.title)
@@ -225,8 +219,10 @@ class InvestigationValidator:
     def _validate_assays(self, assays: Tuple[models.AssayInfo, ...], study_id: str):
         # Check if any assays exists (according to specs, having an assays is not mandatory)
         if not assays:
-            tpl = "No assays declared in study '{}' of investigation '{}'"
-            msg = tpl.format(study_id, self._investigation.info.path)
+            msg = (
+                f'No assays declared in study "{study_id}" of '
+                f'investigation "{self._investigation.info.path}"'
+            )
             warnings.warn(msg, AdvisoryIsaValidationWarning)
             return
         for assay in assays:
@@ -243,25 +239,24 @@ class InvestigationValidator:
                 else assay.technology_type
             )
             if not (assay.path and meas_type and tech_type):
-                tpl = (
+                msg = (
                     "Assay with incomplete minimal information (path, measurement and "
-                    "technology type):\nPath:\t{}\nMeasurement Type:\t{}\nTechnology Type:\t{"
-                    "}\nTechnology Platform:\t{}"
+                    f"technology type):\nPath:\t{assay.path or ''}\n"
+                    f"Measurement Type:\t{meas_type}\nTechnology Type:\t{tech_type}\n"
+                    f"Technology Platform:\t{assay.platform}"
                 )
-                msg = tpl.format(assay.path or "", meas_type, tech_type, assay.platform)
                 warnings.warn(msg, CriticalIsaValidationWarning)
             if not assay.platform:
-                tpl = (
-                    "Assay without platform:\nPath:\t{}"
-                    "\nMeasurement Type:\t{}\nTechnology Type:\t{}\nTechnology Platform:\t{}"
+                msg = (
+                    f"Assay without platform:\nPath:\t{assay.path or ''}"
+                    f"\nMeasurement Type:\t{meas_type}\nTechnology Type:\t{tech_type}\n"
+                    f"Technology Platform:\t{assay.platform}"
                 )
-                msg = tpl.format(assay.path or "", meas_type, tech_type, assay.platform)
                 warnings.warn(msg, AdvisoryIsaValidationWarning)
             # Assure distinct assays, i.e. unique paths
             if assay.path:
                 if assay.path in self._assay_paths:
-                    tpl = "Assay path used more than once: {}"
-                    msg = tpl.format(assay.path or "")
+                    msg = f"Assay path used more than once: {assay.path or ''}"
                     warnings.warn(msg, CriticalIsaValidationWarning)
                 else:
                     self._assay_paths.add(assay.path)

--- a/altamisa/isatab/write_assay_study.py
+++ b/altamisa/isatab/write_assay_study.py
@@ -251,8 +251,7 @@ class _WriterBase:
                 # self._headers.append(node.headers)
             else:  # pragma: no cover
                 # TODO: create new headers based on attributes
-                tpl = "No reference headers available in node {} of first row"
-                msg = tpl.format(node.unique_name)
+                msg = f"No reference headers available in node {node.unique_name} of first row"
                 raise WriteIsatabException(msg)
 
     def _write_headers(self):
@@ -265,18 +264,16 @@ class _WriterBase:
         for row in self._ref_table:
             # Number of nodes per row must match number of header groups
             if len(row) < len(self._headers):
-                tpl = (
+                msg = (
                     "Fewer nodes in row than header groups available:"
-                    "\n\tHeader groups:\t{}\n\tRow nodes:\t{}"
+                    f"\n\tHeader groups:\t{self._headers}\n\tRow nodes:\t{row}"
                 )
-                msg = tpl.format(self._headers, row)
                 raise WriteIsatabException(msg)
             elif len(row) > len(self._headers):
-                tpl = (
+                msg = (
                     "More nodes in row than header groups available:"
-                    "\n\tHeader groups:\t{}\n\tRow nodes:\t{}"
+                    f"\n\tHeader groups:\t{self._headers}\n\tRow nodes:\t{row}"
                 )
-                msg = tpl.format(self._headers, row)
                 raise WriteIsatabException(msg)
 
             # Iterate nodes and corresponding headers
@@ -292,8 +289,7 @@ class _WriterBase:
                     self._append_attribute(line, attributes, header, node)
                 # Iterating the headers should deplete attributes
                 if len(attributes) > 0:  # pragma: no cover
-                    tpl = "Leftover attributes {} found in node {}"
-                    msg = tpl.format(attributes, node.unique_name)
+                    msg = f"Leftover attributes {attributes} found in node {node.unique_name}"
                     raise WriteIsatabException(msg)
             self._write_next_line(line)
 
@@ -318,8 +314,10 @@ class _WriterBase:
                 line.append(attribute)
             self._previous_attribute = attribute
         else:  # pragma: no cover
-            tpl = "Expected '{}' not found in node '{}' after/for attribute '{}'"
-            msg = tpl.format(header, node.unique_name, self._previous_attribute)
+            msg = (
+                f'Expected {header} not found in node "{node.unique_name}" '
+                f'after/for attribute "{self._previous_attribute}"'
+            )
             raise WriteIsatabException(msg)
 
     @staticmethod
@@ -328,8 +326,10 @@ class _WriterBase:
         if is_ontology_term_ref(attribute):
             line.extend([attribute.ontology_name or "", attribute.accession or ""])
         else:  # pragma: no cover
-            tpl = "Expected {} not found in attribute {} of node {}"
-            msg = tpl.format(header, attribute, node.unique_name)
+            msg = (
+                f'Expected {header} not found in attribute "{attribute}" of node '
+                f'"{node.unique_name}"'
+            )
             raise WriteIsatabException(msg)
 
     @staticmethod
@@ -382,8 +382,7 @@ class _WriterBase:
         elif hasattr(node, "parameter_values"):  # is process node
             attributes = self._extract_process(node)
         else:  # unknown node type  # pragma: no cover
-            tpl = "Node of unexpected type (not material/data nor process): {}"
-            msg = tpl.format(node)
+            msg = f"Node of unexpected type (not material/data nor process): {node}"
             raise WriteIsatabException(msg)
         return attributes
 

--- a/altamisa/isatab/write_investigation.py
+++ b/altamisa/isatab/write_investigation.py
@@ -39,8 +39,7 @@ def _extract_section_header(first_entry, section_name):
         # TODO: check that headers and attributes match
         return first_entry.headers
     else:
-        tpl = "No reference headers available for section {}. Applying default order."
-        msg = tpl.format(section_name)
+        msg = f"No reference headers available for section {section_name}. Applying default order."
         warnings.warn(msg, WriteIsatabWarning)
         return None
 
@@ -125,7 +124,7 @@ class InvestigationWriter:
         # Add comments to section dict
         if comments:
             for key, value in comments.items():
-                section["Comment[{}]".format(key)] = value
+                section[f"Comment[{key}]"] = value
         # Write the section name
         self._writer.writerow((section_name,))
         # Write the lines in this section.
@@ -144,12 +143,10 @@ class InvestigationWriter:
                 values = section.pop(header)
                 self._write_line(header, values)
             else:  # pragma: no cover
-                tpl = "No data found for header {} in section {}"
-                msg = tpl.format(header, section_name)
+                msg = f"No data found for header {header} in section {section_name}"
                 raise WriteIsatabException(msg)
         if len(section) > 0:  # pragma: no cover
-            tpl = "Leftover rows found in section {}:\n{}"
-            msg = tpl.format(section_name, section)
+            msg = f"Leftover rows found in section {section_name}:\n{section}"
             raise WriteIsatabException(msg)
 
     def _write_ontology_source_reference(self):

--- a/docs/examples/process_isa_model.py
+++ b/docs/examples/process_isa_model.py
@@ -34,15 +34,13 @@ assays = {}
 for s, study_info in enumerate(investigation.studies):
     if study_info.info.path:
         with open(os.path.join(path_in, study_info.info.path), "rt") as inputf:
-            studies[s] = StudyReader.from_stream("S{}".format(s + 1), inputf).read()
+            studies[s] = StudyReader.from_stream(f"S{s + 1}", inputf).read()
     if study_info.assays:
         assays[s] = {}
     for a, assay_info in enumerate(study_info.assays):
         if assay_info.path:
             with open(os.path.join(path_in, assay_info.path), "rt") as inputf:
-                assays[s][a] = AssayReader.from_stream(
-                    "S{}".format(s + 1), "A{}".format(a + 1), inputf
-                ).read()
+                assays[s][a] = AssayReader.from_stream(f"S{s + 1}", f"A{a + 1}", inputf).read()
 
 # Validate studies and assays
 for s, study_info in enumerate(investigation.studies):

--- a/tests/__snapshots__/test_apps.ambr
+++ b/tests/__snapshots__/test_apps.ambr
@@ -6,7 +6,8 @@
       	ID:	i_minimal
       	Title:	Minimal Investigation
       	Path:	i_minimal.txt
-      	Submission Date:	
+      	Description:	
+      	Submission Date:	None
       	Public Release Date:	None
       	Prefer recording metadata in the study section.
     ''',
@@ -42,7 +43,8 @@
       	ID:	i_warnings
       	Title:	Investigation with Warnings
       	Path:	i_warnings.txt
-      	Submission Date:	
+      	Description:	
+      	Submission Date:	None
       	Public Release Date:	None
       	Prefer recording metadata in the study section.
     ''',

--- a/tests/__snapshots__/test_parse_study.ambr
+++ b/tests/__snapshots__/test_parse_study.ambr
@@ -6,7 +6,8 @@
       	ID:	i_minimal
       	Title:	Minimal Investigation
       	Path:	i_minimal.txt
-      	Submission Date:	
+      	Description:	
+      	Submission Date:	None
       	Public Release Date:	None
       	Prefer recording metadata in the study section.
     ''',
@@ -26,7 +27,8 @@
       	ID:	i_minimal
       	Title:	Minimal Investigation
       	Path:	<no file>
-      	Submission Date:	
+      	Description:	
+      	Submission Date:	None
       	Public Release Date:	None
       	Prefer recording metadata in the study section.
     ''',
@@ -46,7 +48,8 @@
       	ID:	i_minimal
       	Title:	Minimal Investigation
       	Path:	<no file>
-      	Submission Date:	
+      	Description:	
+      	Submission Date:	None
       	Public Release Date:	None
       	Prefer recording metadata in the study section.
     ''',
@@ -66,7 +69,8 @@
       	ID:	i_small
       	Title:	Small Investigation
       	Path:	i_small.txt
-      	Submission Date:	
+      	Description:	
+      	Submission Date:	None
       	Public Release Date:	None
       	Prefer recording metadata in the study section.
     ''',

--- a/tests/test_parse_investigation.py
+++ b/tests/test_parse_investigation.py
@@ -909,7 +909,7 @@ def test_parse_assays_investigation(assays_investigation_file):
     )
     assert record[1].category == ParseIsatabWarning
     assert str(record[1].message) == msg
-    msg = "No assays declared in study 's_assays' of investigation 'i_assays.txt'"
+    msg = 'No assays declared in study "s_assays" of investigation "i_assays.txt"'
     assert record[2].category == AdvisoryIsaValidationWarning
     assert str(record[2].message) == msg
     msg = "Study identifier used more than once: s_assays"

--- a/tests/test_write_assay.py
+++ b/tests/test_write_assay.py
@@ -180,8 +180,9 @@ def test_assay_writer_gelelect(gelelect_investigation_file, tmp_path):
     assert str(record[0].message) == msg
     msg = (
         "Investigation with only one study contains metadata:\n\tID:\t1551099271112"
-        "\n\tTitle:\tInvestigation\n\tPath:\ti_Investigation.txt\n\tSubmission Date:\t\n\tPublic Release"
-        " Date:\tNone\n\tPrefer recording metadata in the study section."
+        "\n\tTitle:\tInvestigation\n\tPath:\ti_Investigation.txt\n\tDescription:\t\n"
+        "\tSubmission Date:\tNone\n\tPublic Release Date:\tNone\n"
+        "\tPrefer recording metadata in the study section."
     )
     assert record[1].category == ModerateIsaValidationWarning
     assert str(record[1].message) == msg

--- a/tests/test_write_assay.py
+++ b/tests/test_write_assay.py
@@ -36,12 +36,10 @@ def _parse_write_assert_assay(investigation_file, tmp_path, quote=None, normaliz
                 continue
             # Load assay
             if not assay_info.path:
-                raise ValueError("Assay {} has no path".format(assay_info))
+                raise ValueError(f"Assay {assay_info} has no path")
             path_in = os.path.join(directory, assay_info.path)
             with open(path_in, "rt") as inputf:
-                assay = AssayReader.from_stream(
-                    "S{}".format(s + 1), "A{}".format(a + 1), inputf
-                ).read()
+                assay = AssayReader.from_stream(f"S{s + 1}", f"A{a + 1}", inputf).read()
             AssayValidator(investigation, study_info, assay_info, assay).validate()
             # Write assay to temporary file
             path_out = tmp_path / assay_info.path
@@ -51,9 +49,7 @@ def _parse_write_assert_assay(investigation_file, tmp_path, quote=None, normaliz
                 # Read and write assay again
                 path_in = path_out
                 with open(path_out, "rt") as inputf:
-                    assay = AssayReader.from_stream(
-                        "S{}".format(s + 1), "A{}".format(a + 1), inputf
-                    ).read()
+                    assay = AssayReader.from_stream(f"S{s + 1}", f"A{a + 1}", inputf).read()
                 AssayValidator(investigation, study_info, assay_info, assay).validate()
                 path_out = tmp_path / (assay_info.path.name + "_b")
                 with open(path_out, "wt", newline="") as file:

--- a/tests/test_write_study.py
+++ b/tests/test_write_study.py
@@ -31,10 +31,10 @@ def _parse_write_assert(investigation_file, tmp_path, quote=None):
     for s, study_info in enumerate(investigation.studies):
         # Load study
         if not study_info.info.path:
-            raise ValueError("Study {} has no path".format(study_info))
+            raise ValueError(f"Study {study_info} has no path")
         path_in = os.path.join(directory, study_info.info.path)
         with open(path_in, "rt") as inputf:
-            study = StudyReader.from_stream("S{}".format(s + 1), inputf).read()
+            study = StudyReader.from_stream(f"S{s + 1}", inputf).read()
         StudyValidator(investigation, study_info, study).validate()
         # Write study to temporary file
         path_out = tmp_path / study_info.info.path

--- a/tests/test_write_study.py
+++ b/tests/test_write_study.py
@@ -88,8 +88,8 @@ def test_study_writer_gelelect(gelelect_investigation_file, tmp_path):
     assert str(record[0].message) == msg
     msg = (
         "Investigation with only one study contains metadata:\n\tID:\t1551099271112\n\tTitle:\t"
-        "Investigation\n\tPath:\ti_Investigation.txt\n\tSubmission Date:\t\n\tPublic Release "
-        "Date:\tNone\n\tPrefer recording metadata in the study section."
+        "Investigation\n\tPath:\ti_Investigation.txt\n\tDescription:\t\n\tSubmission Date:\tNone\n"
+        "\tPublic Release Date:\tNone\n\tPrefer recording metadata in the study section."
     )
     assert record[1].category == ModerateIsaValidationWarning
     assert str(record[1].message) == msg


### PR DESCRIPTION
Converted `.format` and ` % ` operator to f-strings where it improves readability  and does not clash with the 100 character line length limit.

closes #116 